### PR TITLE
Make menu sticky on scroll

### DIFF
--- a/style-v2.css
+++ b/style-v2.css
@@ -718,6 +718,7 @@ footer a:focus {
     display: flex;
   }
   .header-container {
-    position: relative;
+    position: sticky;
+    top: 0;
   }
 } 


### PR DESCRIPTION
## Summary
- keep header sticky in mobile breakpoint so navigation remains visible while scrolling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68421f965584832c95d1b9ff949333fc